### PR TITLE
Remove custom build.yaml

### DIFF
--- a/babybuddy/Dockerfile
+++ b/babybuddy/Dockerfile
@@ -1,6 +1,6 @@
-ARG BUILD_FROM=ghcr.io/hassio-addons/base/amd64:11.1.0
-# hadolint ignore=DL3006
-FROM ${BUILD_FROM}
+# https://developers.home-assistant.io/docs/add-ons/configuration#add-on-dockerfile
+ARG BUILD_FROM
+FROM $BUILD_FROM
 
 # Set shell
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/babybuddy/build.yaml
+++ b/babybuddy/build.yaml
@@ -1,7 +1,0 @@
-# https://developers.home-assistant.io/docs/add-ons/configuration#add-on-dockerfile
-build_from:
-  aarch64: ghcr.io/hassio-addons/base/aarch64:latest
-  amd64: ghcr.io/hassio-addons/base/amd64:latest
-  armhf: ghcr.io/hassio-addons/base/armhf:latest
-  armv7: ghcr.io/hassio-addons/base/armv7:latest
-  i386: ghcr.io/hassio-addons/base/i386:latest

--- a/babybuddy/build.yaml
+++ b/babybuddy/build.yaml
@@ -1,7 +1,7 @@
----
+# https://developers.home-assistant.io/docs/add-ons/configuration#add-on-dockerfile
 build_from:
-  aarch64: ghcr.io/hassio-addons/base/aarch64:11.0.1
-  amd64: ghcr.io/hassio-addons/base/amd64:11.0.1
-  armhf: ghcr.io/hassio-addons/base/armhf:11.0.1
-  armv7: ghcr.io/hassio-addons/base/armv7:11.0.1
-  i386: ghcr.io/hassio-addons/base/i386:11.0.1
+  aarch64: ghcr.io/hassio-addons/base/aarch64:latest
+  amd64: ghcr.io/hassio-addons/base/amd64:latest
+  armhf: ghcr.io/hassio-addons/base/armhf:latest
+  armv7: ghcr.io/hassio-addons/base/armv7:latest
+  i386: ghcr.io/hassio-addons/base/i386:latest


### PR DESCRIPTION
# What

Removed the custom build.yaml that was causing install to break.

# Why

Fixes the install. 

1. Fixes #4
1. Fixes #5

# How

Not entirely sure. Seems like the docker images we were pinned to were not compatible. Tested this by making changes and installing my custom version. Installed and booted up successfully.