### PR TITLE
feat: fix ingress configuration

### DIFF
--- a/babybuddy/DOCS.md
+++ b/babybuddy/DOCS.md
@@ -12,4 +12,9 @@ If you are hosting your baby buddy via another domain (such as babybuddy.mydomai
 Access baby buddy through this port. (ex: hassio.local:8889 when set to 8889)
 
 ## Ingress
-Ingress does not work at the moment, however this is under development and should come to a release in the future.
+
+### Option: `INGRESS_USER` (default: blank)
+
+Automatically log in as this user using HomeAssistant ingress (e.g. `admin`) if set. 
+
+**WARNING** this enables header based authentication so do not use in conjunction with publicly exposing the network port above.

--- a/babybuddy/config.yaml
+++ b/babybuddy/config.yaml
@@ -22,12 +22,14 @@ options:
   NAP_START_MIN: "06:00"
   NAP_START_MAX: "18:00"
   USE_24_HOUR_TIME_FORMAT: False
+  INGRESS_USER: ""  
   log_level: info
 schema: 
   CSRF_TRUSTED_ORIGINS: str
   NAP_START_MIN: str
   NAP_START_MAX: str
   USE_24_HOUR_TIME_FORMAT: bool
+  INGRESS_USER: str  
   log_level: list(debug|info|warning|error|critical)
 ports:
   8000/tcp: null

--- a/babybuddy/rootfs/etc/cont-init.d/nginx.sh
+++ b/babybuddy/rootfs/etc/cont-init.d/nginx.sh
@@ -4,6 +4,7 @@
 bashio::var.json \
     interface "$(bashio::addon.ip_address)" \
     port "^$(bashio::addon.ingress_port)" \
+    remoteuser "$(bashio::config "INGRESS_USER")" \
     | tempio \
         -template /etc/nginx/templates/ingress.gtpl \
         -out /etc/nginx/servers/ingress.conf

--- a/babybuddy/rootfs/etc/nginx/templates/ingress.gtpl
+++ b/babybuddy/rootfs/etc/nginx/templates/ingress.gtpl
@@ -9,5 +9,20 @@ server {
         deny    all;
 
         proxy_pass http://backend;
+
+        absolute_redirect off;
+        proxy_redirect '/' $http_x_ingress_path/;
+        sub_filter 'href="/' 'href="$http_x_ingress_path/';
+        sub_filter 'href=/>' 'href="$http_x_ingress_path/">'; # Top left home icon
+        sub_filter 'action="/' 'action="$http_x_ingress_path/';
+        sub_filter '<script src="/' '<script src="$http_x_ingress_path/';
+        sub_filter '<img src="/' '<img src="$http_x_ingress_path/';
+        sub_filter "top.location.href='" "top.location.href='$http_x_ingress_path";
+
+        sub_filter_once off;
+    {{ if .remoteuser }}
+        proxy_set_header X-Remote-User '{{ .remoteuser }}';
+    {{- end }}
+        proxy_hide_header x-frame-options; # X-Frame denied by default
     }
 }

--- a/babybuddy/rootfs/etc/services.d/babybuddy/run
+++ b/babybuddy/rootfs/etc/services.d/babybuddy/run
@@ -24,7 +24,14 @@ export \
     CSRF_TRUSTED_ORIGINS=$(bashio::config "CSRF_TRUSTED_ORIGINS") \
     NAP_START_MIN=$(bashio::config "NAP_START_MIN") \
     NAP_START_MAX=$(bashio::config "NAP_START_MAX") \
-    USE_24_HOUR_TIME_FORMAT=$(bashio::config "USE_24_HOUR_TIME_FORMAT") 
+    USE_24_HOUR_TIME_FORMAT=$(bashio::config "USE_24_HOUR_TIME_FORMAT")
+
+if bashio::config.has_value "INGRESS_USER"; then
+    bashio::log.info 'Adding config for Ingress User Auth'
+    export \
+        REVERSE_PROXY_AUTH=true \
+        PROXY_HEADER=HTTP_X_REMOTE_USER
+fi
 
 exec \
     s6-setuidgid root gunicorn babybuddy.wsgi "${options[@]}"


### PR DESCRIPTION
Hopefully getting #2 resolved by adding some custom nginx entries to rewrite resource paths with the ingress prefix provided in HTTP headers.

Additionally, optional support for automatic auth via ingress to skip login prompt by specifying login username in addon configuration.

The subpath option discussed in #2 seemed to affect both the direct port forward as well in my testing and would have required a breaking change for all exisiting users, so this should allow both ingress and port forwards to co-exist where desired.