### PR TITLE
Update build.yaml

### DIFF
--- a/babybuddy/build.yaml
+++ b/babybuddy/build.yaml
@@ -1,7 +1,7 @@
 ---
 build_from:
-  aarch64: ghcr.io/hassio-addons/base:12.2.7
-  amd64: ghcr.io/hassio-addons/base:12.2.7
-  armhf: ghcr.io/hassio-addons/base:12.2.7
-  armv7: ghcr.io/hassio-addons/base:12.2.7
-  i386: ghcr.io/hassio-addons/base:12.2.7
+  aarch64: ghcr.io/hassio-addons/base:13.1.2
+  amd64: ghcr.io/hassio-addons/base:13.1.2
+  armhf: ghcr.io/hassio-addons/base:13.1.2
+  armv7: ghcr.io/hassio-addons/base:13.1.2
+  i386: ghcr.io/hassio-addons/base:13.1.2


### PR DESCRIPTION
Ran into a dependency conflict when trying to reinstall the add in. Reviewed previous errors and looks like updating the version resolved the issue for me. 