### PR TITLE
Add homeassistant-config with different notification data store

### DIFF
--- a/babybuddy/root/app/babybuddy/babybuddy/settings/homeassistant.py
+++ b/babybuddy/root/app/babybuddy/babybuddy/settings/homeassistant.py
@@ -1,0 +1,4 @@
+from .base import *
+
+ENABLE_HOME_ASSISTANT_SUPPORT = True
+MESSAGE_STORAGE = "django.contrib.messages.storage.session.SessionStorage"

--- a/babybuddy/root/etc/cont-init.d/babybuddy.sh
+++ b/babybuddy/root/etc/cont-init.d/babybuddy.sh
@@ -20,7 +20,7 @@ if [ ! -f "/config/.secretkey" ]; then
         | tr -d '\n' > /config/.secretkey
 fi
 export \
-    DJANGO_SETTINGS_MODULE="babybuddy.settings.base" \
+    DJANGO_SETTINGS_MODULE="babybuddy.settings.homeassistant" \
     ALLOWED_HOSTS="${ALLOWED_HOSTS:-*}" \
     TIME_ZONE="${TZ:-UTC}" \
     DEBUG="${DEBUG:-False}" \

--- a/babybuddy/root/etc/services.d/babybuddy/run
+++ b/babybuddy/root/etc/services.d/babybuddy/run
@@ -14,7 +14,7 @@ options+=(--worker-class=gthread)
 cd /app/babybuddy || bashio.exit.nok 'Failed cd, /app/babybuddy does not exist, exiting...'
 
 export \
-    DJANGO_SETTINGS_MODULE="babybuddy.settings.base" \
+    DJANGO_SETTINGS_MODULE="babybuddy.settings.homeassistant" \
     ALLOWED_HOSTS="${ALLOWED_HOSTS:-*}" \
     TIME_ZONE="${TZ:-UTC}" \
     DEBUG="${DEBUG:-False}" \


### PR DESCRIPTION
Fixes #31

I feel that many users are affected by this, and maybe it is time to accept the "workaround solution" I proposed some time back to get things unstuck.

What I did:
- Define a custom `homeasstant.py` configuration and set all the relevant homeassistant-specific settings in one place. I added `ENABLE_HOME_ASSISTANT_SUPPORT = True` for good measure as well... not necessary but seemed to make sense.