### PR TITLE
Fix Issue #13: Serve Child Images Stored in Media Directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ If you'd like to make a modification to Baby Buddy, fork this repo and add your 
 
 Access BB though ingress in HA as you normally would. If you would like to skip the login process, there is a way to auto-login, but please be aware of the security implications. [See more in the docs](https://github.com/OttPeterR/addon-babybuddy/blob/main/babybuddy/DOCS.md)
 
-Alternatively if you configure a port in the addon configuration, you can access through `http://your-home-assistant.local:PORT`. This is what you must do if you want to host BB with another name (such as mydomain.duckdns.org/babybuddy) without using the Home Assistant NGINX addon installation process described below.
+Alternatively, you can configure the Home Assistant Nginx Proxy Manager using the instructions below to access Baby Buddy via your custom domain (e.g., `babybuddy.example.duckdns.org`).
+
+You can also expose the port to the Baby Buddy Django instance on your host machine to access Baby Buddy through `http://your-home-assistant.local:PORT`. However, this approach will not serve user uploaded content (e.g., child images stored in the `/media/` directory).
 
 If you come across a `CSRF_TRUSTED_ORIGINS` error, you can add that domain in the addon's `Configuration` page. Multiple domains can be added with a comma and no space to separate them.
 

--- a/README.md
+++ b/README.md
@@ -1,46 +1,54 @@
 # Baby Buddy - Home Assistant Addon
+
 Run Baby Buddy on Home Assistant!
 
 ## Other Important Repos
+
 - [Baby Buddy Integration](https://github.com/jcgoette/baby_buddy_homeassistant)
   - get BB data as sensors and entities in HA so you can automate! You can install this from HACS.
 - [Baby Buddy Source Code](https://github.com/babybuddy/babybuddy)
   - application code is located in that repo, the repo you are currently viewing simply takes that code and wraps it up into a Home Assistant addon
 
 ## Contributing
+
 PRs welcome!
 
 If you'd like to make a modification to Baby Buddy, fork this repo and add your changes! There's a github action that builds the container so you can check that your code works. See [here](https://developers.home-assistant.io/docs/add-ons/) for more info about developing Home Assistant Add-Ons
 
 # Accessing Baby Buddy
+
 Access BB though ingress in HA as you normally would. If you would like to skip the login process, there is a way to auto-login, but please be aware of the security implications. [See more in the docs](https://github.com/OttPeterR/addon-babybuddy/blob/main/babybuddy/DOCS.md)
 
-Alternatively if you configure a port in the addon configuration, you can access through `http://your-home-assistant.local:PORT`. This is what you must do if you want to host BB with another name (such as mydomain.duckdns.org/babybuddy)
+Alternatively if you configure a port in the addon configuration, you can access through `http://your-home-assistant.local:PORT`. This is what you must do if you want to host BB with another name (such as mydomain.duckdns.org/babybuddy) without using the Home Assistant NGINX addon installation process described below.
 
 If you come across a `CSRF_TRUSTED_ORIGINS` error, you can add that domain in the addon's `Configuration` page. Multiple domains can be added with a comma and no space to separate them.
 
 ## Home Assistant Integration
+
 This addon only runs Baby Buddy, if you would like to see some of the data as sensors in Home Asssitant to crete automations, you also need [the integration](https://github.com/jcgoette/baby_buddy_homeassistant) that pulls data from the addon.
 
 ## Installation (basic)
-Add this addon-repo to your home assistant by going to to **Settings** -> **Add-ons** -> **Add-on Store** and add this URL as an additional repository: 
+
+Add this addon-repo to your home assistant by going to to **Settings** -> **Add-ons** -> **Add-on Store** and add this URL as an additional repository:
+
 ```txt
 https://github.com/OttPeterR/addon-babybuddy
 ```
 
 ### Additional setup for HTTPS via NGINX (using your own domain)
+
 The standard way of accessing Baby Buddy is through Home Assistant Ingress, so under normal use these instructions won't be needed.
 
 Follow these additional instructions if your Home Assistant instance is set up so that it can only be accessed via HTTPS (e.g., using the [DuckDNS add-on](https://github.com/home-assistant/addons/tree/master/duckdns). For example, you access your Home Assistant instance at `https://example.duckdns.org:8123`.
 
-1. Install the [Nginx Proxy Manager](https://github.com/hassio-addons/addon-nginx-proxy-manager) available from the Home Assistant Add-on Store. Closely follow the [installation instructions](https://github.com/hassio-addons/addon-nginx-proxy-manager/blob/main/proxy-manager/DOCS.md). We will use this add-on the set up a reverse proxy so that you can access BabyBuddy via HTTPS externally. 
+1. Install the [Nginx Proxy Manager](https://github.com/hassio-addons/addon-nginx-proxy-manager) available from the Home Assistant Add-on Store. Closely follow the [installation instructions](https://github.com/hassio-addons/addon-nginx-proxy-manager/blob/main/proxy-manager/DOCS.md). We will use this add-on the set up a reverse proxy so that you can access BabyBuddy via HTTPS externally.
 
 2. From a machine on the same local network as your Home Assistant instance, identify the local IP address of the Home Assistant machine (e.g., `192.168.1.100`). Then, direct your browser to `http://192.168.1.100:81` to access the Nginx Proxy Manager admin page. *(Note, even though Home Assistant is set up to only be accessed on your domain via HTTPS, you can access Nginx Proxy Manager locally because it is an add-on running in a separate Docker container. The Nginx Proxy Manager admin page will only ever be accessible via your local network for security reasons, assuming your router does not forward port `81` to your Home Assistant machine)*
 
-3. Forward port `80` and `443` on your router to your Home Assistant machine. These ports will be sent to the Nginx Proxy Manager add-on, and not directly to Home Assistant Core. This will allow you to access Baby Buddy via HTTPS on your domain. 
+3. Forward port `80` and `443` on your router to your Home Assistant machine. These ports will be sent to the Nginx Proxy Manager add-on, and not directly to Home Assistant Core. This will allow you to access Baby Buddy via HTTPS on your domain.
 
-4. On the Nginx Proxy Manager admin dashboard, navigate to **Hosts** -> **Proxy Hosts** -> **Add Proxy Host**. Enter the domain you want to use to access Baby Budy (e.g., `babybuddy.example.duckdns.org`). Use `http` as the scheme (i.e., how Baby Buddy is accessed locally). Enter the Home Assistant local IP address as the Forward IP (e.g. `192.168.1.100`). Enter `8000` as the forward port (or whatever you have set up in the Baby Buddy add-on configuration as the port.) Under the **SSL** tab, select ***Request a new SSL certificate*** and check ***Force SSL*** and agree. 
+4. On the Nginx Proxy Manager admin dashboard, navigate to **Hosts** -> **Proxy Hosts** -> **Add Proxy Host**. Enter the domain you want to use to access Baby Budy (e.g., `babybuddy.example.duckdns.org`). Use `http` as the scheme (i.e., how Baby Buddy is accessed locally). Enter the hostname of the Baby Buddy addon container on the Home Assistant internal network. This hostname is most liekly `68152197-baby-buddy` unless you installed the Baby Buddy addon in a non-standard way (e.g., if you copied the source to your local addons directory, the hostname would instead be `local-baby-buddy`). Enter `1337` as the forward port (This is the port that Baby Buddy would expect Ingress to use, but we'll use it with this approach too.) Under the **SSL** tab, select **_Request a new SSL certificate_** and check **_Force SSL_** and agree.
 
-5. In the Baby Budy add-on configuration, under `CSRF_TRUSTED_ORIGINS` enter your domain for Baby Buddy (e.g., `https://babybuddy.example.duckdns.org`). If you want to use multiple domains, enter them with a comma and no space (eg `http://baby.example.com,https://babybuddy.mydomain.com`) 
+5. In the Baby Budy add-on configuration, under `CSRF_TRUSTED_ORIGINS` enter your domain for Baby Buddy (e.g., `https://babybuddy.example.duckdns.org`). If you want to use multiple domains, enter them with a comma and no space (eg `http://baby.example.com,https://babybuddy.mydomain.com`) You do NOT need to expose a port for the web interface.
 
-You should now be able to acess Baby Buddy via your domain (e.g., [https://babybuddy.example.duckdns.org]). You may want to use a Markdown card or a Button set up to your domain. 
+You should now be able to acess Baby Buddy via your domain (e.g., [https://babybuddy.example.duckdns.org]). You may want to use a Markdown card or a Button set up to your domain.

--- a/babybuddy/DOCS.md
+++ b/babybuddy/DOCS.md
@@ -12,7 +12,7 @@ If you are hosting your baby buddy via another domain (such as babybuddy.mydomai
 
 ### Option: `Network port`
 
-Access baby buddy through this port. (ex: hassio.local:8889 when set to 8889) Be sure to check that this port is not already taken.
+Access baby buddy through this port on your host machine. (ex: hassio.local:8889 when set to 8889) Be sure to check that this port is not already taken.
 
 ### Option: `NAP_START_MIN` and `NAP_START_MAX`
 

--- a/babybuddy/Dockerfile
+++ b/babybuddy/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=ghcr.io/hassio-addons/base:16.3.6
+ARG BUILD_FROM=ghcr.io/hassio-addons/base:17.2.1
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 

--- a/babybuddy/build.yaml
+++ b/babybuddy/build.yaml
@@ -1,7 +1,7 @@
 ---
 build_from:
-  aarch64: ghcr.io/hassio-addons/base:16.3.6
-  amd64: ghcr.io/hassio-addons/base:16.3.6
-  armhf: ghcr.io/hassio-addons/base:16.3.6
-  armv7: ghcr.io/hassio-addons/base:16.3.6
-  i386: ghcr.io/hassio-addons/base:16.3.6
+  aarch64: ghcr.io/hassio-addons/base:17.2.1
+  amd64: ghcr.io/hassio-addons/base:17.2.1
+  armhf: ghcr.io/hassio-addons/base:17.2.1
+  armv7: ghcr.io/hassio-addons/base:17.2.1
+  i386: ghcr.io/hassio-addons/base:17.2.1

--- a/babybuddy/root/etc/nginx/templates/ingress.gtpl
+++ b/babybuddy/root/etc/nginx/templates/ingress.gtpl
@@ -4,8 +4,9 @@ server {
     include /etc/nginx/includes/server_params.conf;
     include /etc/nginx/includes/proxy_params.conf;
 
-    location /media {
-        root /app/babybuddy;
+    location /media/ {
+        root /app/babybuddy/media/;
+        try_files $uri =404;
     }
 
     location /static {

--- a/babybuddy/root/etc/nginx/templates/ingress.gtpl
+++ b/babybuddy/root/etc/nginx/templates/ingress.gtpl
@@ -5,16 +5,17 @@ server {
     include /etc/nginx/includes/proxy_params.conf;
 
     location /media/ {
-        root /app/babybuddy/media/;
+        alias /app/babybuddy/media/;
         try_files $uri =404;
     }
 
-    location /static {
-        root /app/babybuddy;
+    location /static/ {
+        alias /app/babybuddy/static/;
+        try_files $uri =404;
     }
 
     location / {
-        allow   172.30.32.2;
+        allow   172.30.32.0/23;
         deny    all;
 
         proxy_pass http://backend;

--- a/babybuddy/root/etc/nginx/templates/ingress.gtpl
+++ b/babybuddy/root/etc/nginx/templates/ingress.gtpl
@@ -4,14 +4,12 @@ server {
     include /etc/nginx/includes/server_params.conf;
     include /etc/nginx/includes/proxy_params.conf;
 
-    location /media/ {
-        alias /app/babybuddy/media/;
-        try_files $uri =404;
+    location /media {
+        root /app/babybuddy;
     }
 
-    location /static/ {
-        alias /app/babybuddy/static/;
-        try_files $uri =404;
+    location /static {
+        root /app/babybuddy;
     }
 
     location / {


### PR DESCRIPTION
### Fix Issue #13: Serve Child Images Stored in Media Directory

This pull request addresses [Issue 13](https://github.com/OttPeterR/addon-babybuddy/issues/13), where child images stored in the media directory were not being served (when using an nginx proxy manager for external access).

### Changes Made:

1. **README.md**: Changed the recommended way of installing alongside the nginx proxy manager addon. Instead of having nginx point to the host device port that is forwarded to Baby Buddy (e.g., `8000`), instead the proxy manager should forward directly to the Baby Buddy container on port `1337` the same way that ingress does. It is no longer necessary to make the Baby Buddy port accessible on the device host. 

2. **babybuddy/root/etc/nginx/templates/ingress.gtpl**: When nginx proxy manager Home Assistant addon proxies the request from the external domain to Baby Buddy, it sends it to the nginx instance running inside of the Baby Buddy addon which is necessary to serve content from the `/media/` directory separately from Django. However, the serving of the `/media/` directory is defined in the `nginx/servers/ingress.conf` configuration which limits allowable requests from only `172.30.32.2` (i.e., the IP address of the `hassio_supervisor` container). To allow the Nginx Proxy Manager Home Assistant addon to send traffic to Baby Buddy, we need to allow the IP of the Nginx Proxy Manager addon container too. However, this IP may change depending on configuration, so we allow the entire Home Assistant subnet to proxy to the Baby Buddy backend. 

3. **babybuddy/DOCS.md**: Minor clarification about the port on the host machine vs the port on in the Baby Buddy container.

### Security Note

The previous recommended installation methods were to (1) always use Ingress OR (2) always to use an external port. 

1. **Ingress**: By specifying an `INGRESS_USER`, the webUI is passed with an `X-Remote-User` header to the Baby Buddy backend for authentication. Unless Baby Buddy is exposed on an external port, all traffic from the user via Ingress first passes through the `hassio_supervisor` then to the Baby Buddy addon container's Nginx instance, which only allows this traffic from the `hassio_supervisor` (i.e., IP `172.30.32.2`) and denies all other traffic. *(It was recommended to not expose the Baby Buddy app on an external port since specifying an INGRESS_USER configures the Baby Buddy backend to accept header based authentication which could be a publicly exposed vulnerability.)*

2. **External port**: This exposes port `8000` of the Baby Buddy Django server to a port (e.g., `8000` or `8999`) on the Home Assistant host machine. However, this bypasses the Nginx instance built into the Baby Buddy addon, and thus cannot server content in the `/media/` directory.

The modifications in this pull request expose the backend to traffic from any IP in the Home Assistant internal network (i.e., `172.30.32.0/23`, the IPs of any other HA addon container.) This potentially increases the vulnerability of Baby Buddy; however, everything in the HA internal network *should* be trustworthy. I'm not a security expert, but this seems no less secure than exposing port `8000` directly.

