### PR TITLE
fix: apply CSRF_TRUSTED_ORIGINS config to Django settings

### DIFF
--- a/.github/workflows/build-tester.yml
+++ b/.github/workflows/build-tester.yml
@@ -1,6 +1,8 @@
 name: "Build Addon"
 
-on: [pull_request]
+on:
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   aarch64:

--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -3,6 +3,7 @@ name: "Publish Container"
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   aarch64:

--- a/babybuddy/config.yaml
+++ b/babybuddy/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: Baby Buddy
-version: 2.7.1
+version: 2.7.1-test1
 homeassistant: 2023.6.2
 slug: baby_buddy
 image: "ottpeterr/image-{arch}-babybuddy"

--- a/babybuddy/config.yaml
+++ b/babybuddy/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: Baby Buddy
-version: 2.7.1-test1
+version: 2.7.1
 homeassistant: 2023.6.2
 slug: baby_buddy
 image: "ottpeterr/image-{arch}-babybuddy"

--- a/babybuddy/root/app/babybuddy/babybuddy/settings/homeassistant.py
+++ b/babybuddy/root/app/babybuddy/babybuddy/settings/homeassistant.py
@@ -1,4 +1,8 @@
 from .base import *
+import os
 
 ENABLE_HOME_ASSISTANT_SUPPORT = True
 MESSAGE_STORAGE = "django.contrib.messages.storage.session.SessionStorage"
+
+if os.getenv("CSRF_TRUSTED_ORIGINS"):
+    CSRF_TRUSTED_ORIGINS = os.getenv("CSRF_TRUSTED_ORIGINS").split(",")

--- a/babybuddy/root/app/babybuddy/babybuddy/settings/homeassistant.py
+++ b/babybuddy/root/app/babybuddy/babybuddy/settings/homeassistant.py
@@ -1,6 +1,11 @@
 from .base import *
 import os
 
+# Trust the headers passed by Ingress/Nginx
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+USE_X_FORWARDED_HOST = True
+USE_X_FORWARDED_PORT = True
+
 ENABLE_HOME_ASSISTANT_SUPPORT = True
 MESSAGE_STORAGE = "django.contrib.messages.storage.session.SessionStorage"
 


### PR DESCRIPTION
The CSRF_TRUSTED_ORIGINS environment variable was being exported by the run script but was not being read by the Django settings. This caused the addon configuration option to be ignored, leading to CSRF verification errors when using Ingress.

fixes: #81