### PR TITLE
chore: bump bundled Baby Buddy to v2.10.0

### DIFF
--- a/babybuddy/CHANGELOG.md
+++ b/babybuddy/CHANGELOG.md
@@ -1,5 +1,16 @@
 # CHANGELOG
 
+## 2.10.0
+### ⬆️ Updated
+- Bumps bundled Baby Buddy to [2.10.0](https://github.com/babybuddy/babybuddy/releases/tag/v2.10.0) (from 2.9.2).
+### 🆕 Added
+- Loading spinner on submit buttons, preventing double submission (upstream [#1051](https://github.com/babybuddy/babybuddy/pull/1051)).
+- Bidirectional language support in `base.html` (upstream [#1082](https://github.com/babybuddy/babybuddy/pull/1082)).
+### 🐞 Fixed
+- Feeding intervals are computed from feeding end times, including on the dashboard (upstream [#944](https://github.com/babybuddy/babybuddy/pull/944)).
+- Weight and height percentile sorting/slicing mismatch (upstream [#1076](https://github.com/babybuddy/babybuddy/pull/1076)).
+- 500 error on Python 3.14 by allowing django-imagekit >= 6.0 (upstream [#1104](https://github.com/babybuddy/babybuddy/pull/1104)).
+
 ## 2.9.2
 ### ⬆️ Updated
 - Bumps bundled Baby Buddy to [2.9.2](https://github.com/babybuddy/babybuddy/releases/tag/v2.9.2) (from 2.8.0; includes upstream 2.9.0, 2.9.1, and 2.9.2).

--- a/babybuddy/Dockerfile
+++ b/babybuddy/Dockerfile
@@ -3,7 +3,7 @@ ARG BUILD_FROM=ghcr.io/hassio-addons/base:20.0.1
 FROM ${BUILD_FROM}
 
 # Optional: BABYBUDDY_GIT_REF + BABYBUDDY_GIT_URL clone that ref instead of the
-# v2.9.2 tarball (build.yaml `args` or docker --build-arg). Leave unset for release builds.
+# v2.10.0 tarball (build.yaml `args` or docker --build-arg). Leave unset for release builds.
 ARG BABYBUDDY_GIT_REF=
 ARG BABYBUDDY_GIT_URL=https://github.com/babybuddy/babybuddy.git
 
@@ -22,10 +22,10 @@ RUN \
     rm -rf /tmp/babybuddy-src && \
     apk del --no-cache git; \
   else \
-    echo "**** downloading babybuddy v2.9.2 tarball ****" && \
+    echo "**** downloading babybuddy v2.10.0 tarball ****" && \
     curl -o \
     /tmp/babybuddy.tar.gz -L \
-    "https://github.com/babybuddy/babybuddy/archive/refs/tags/v2.9.2.tar.gz" && \
+    "https://github.com/babybuddy/babybuddy/archive/refs/tags/v2.10.0.tar.gz" && \
     mkdir -p /app/babybuddy && \
     tar xf \
     /tmp/babybuddy.tar.gz -C \

--- a/babybuddy/config.yaml
+++ b/babybuddy/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: Baby Buddy
-version: 2.9.2
+version: 2.10.0
 homeassistant: 2023.6.2
 slug: baby_buddy
 image: "ottpeterr/image-{arch}-babybuddy"


### PR DESCRIPTION
Bumps bundled Baby Buddy 2.9.2 → [2.10.0](https://github.com/babybuddy/babybuddy/releases/tag/v2.10.0) (released 2026-08-05). Same shape as #90.

Tested on HAOS (amd64) as a local add-on, so the image was built from the Dockerfile rather than pulled, under a separate slug and data volume: build succeeded, Django migrations applied on a fresh database, gunicorn and nginx up, no errors in the log. The bundled `babybuddy-books` extension installed fine.

Closes #92
